### PR TITLE
Migration der Tests auf phpUnit v10

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 # SNMP
+[![IP-Symcon is awesome!](https://img.shields.io/badge/IP--Symcon-6.2-blue.svg)](https://www.symcon.de)
+[![Check Style](https://github.com/symcon/Aktivliste/workflows/Check%20Style/badge.svg)](https://github.com/symcon/SNMP/actions)
+[![Run Tests](https://github.com/symcon/Aktivliste/workflows/Run%20Tests/badge.svg)](https://github.com/symcon/SNMP/actions)
+
 
 Folgende Module beinhaltet das SNMP Repository:
 

--- a/README.md
+++ b/README.md
@@ -6,5 +6,5 @@
 
 Folgende Module beinhaltet das SNMP Repository:
 
-- __SNMP__ ([Dokumentation](SNMP))  
+- __SNMP__ ([Dokumentation](https://www.symcon.de/de/service/dokumentation/modulreferenz/snmp))  
 	Zeige Werte für beliebige OIDs eines Walks an. Optional können diese als Variable erstellt und beschreiben werden.

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit>
-    <php>
-        <const name="PHPUNIT_TESTSUITE" value="true"/>
-    </php>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">../SNMP</directory>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.1/phpunit.xsd" cacheDirectory=".phpunit.cache">
+  <coverage/>
+  <php>
+    <const name="PHPUNIT_TESTSUITE" value="true"/>
+  </php>
+  <source>
+    <include>
+      <directory suffix=".php">../SNMP</directory>
+    </include>
+  </source>
 </phpunit>


### PR DESCRIPTION
Migration auf phpUnit Version 10.1.1 und Anpassung der Readme für die Dokumentation auf der Seite

Erst mergen wenn https://github.com/symcon/site/pull/2185 gemergt ist.