### PR TITLE
Hinzufügen einer Speicherüberwachung 

### DIFF
--- a/SNMP/form.json
+++ b/SNMP/form.json
@@ -185,25 +185,52 @@
     ],
     "actions": [
         {
-            "caption": "Start Walk",
-            "type": "Button",
-            "name": "StartWalk",
-            "visible": true,
-            "onClick": "SNMP_StartWalkingOIDs($id);"
-        },
-        {
-            "caption": "Stop Walk",
-            "type": "Button",
-            "name": "StopWalk",
-            "visible": false,
-            "onClick": "SNMP_StopWalkingOIDs($id);"
-        },
-        {
-            "caption": "",
-            "type": "ProgressBar",
-            "name": "Bar",
-            "indeterminate": true,
-            "visible": false
+            "type": "RowLayout",
+            "items": [
+                {
+                    "caption": "Start Walk",
+                    "type": "PopupButton",
+                    "name": "StartWalk",
+                    "onClick": "SNMP_StartWalkingOIDs($id);",
+                    "popup": {
+                        "buttons": [
+                            {
+                                "caption": "Cancel",
+                                "type": "Button",
+                                "name": "StopWalk",
+                                "onClick": "SNMP_StopWalkingOIDs($id);"
+                            }
+                        ],
+                        "items": [
+                            {
+                                "caption": "",
+                                "type": "ProgressBar",
+                                "name": "Bar",
+                                "indeterminate": true
+                            }
+                        ]
+                    }
+                },
+                {
+                    "type": "PopupAlert",
+                    "name": "Alert",
+                    "visible": false,
+                    "popup": {
+                        "items": [
+                            {
+                                "type": "Label",
+                                "caption": "",
+                                "name": "AlertLabel"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "type": "Label",
+                    "name": "Count",
+                    "caption": ""
+                }
+            ]
         },
         {
             "caption": "OIDs",

--- a/SNMP/locale.json
+++ b/SNMP/locale.json
@@ -26,7 +26,10 @@
             "seconds": "Sekunden",
             "Please configure Host before starting a walk!": "Bitte Host konfigurieren bevor ein Walk gestartet wird!",
             "Walking...": "Führe Walk durch...",
-            "Walking... %d": "Führe Walk durch... %d"
+            "Walking... %d": "Führe Walk durch... %d",
+            "Cancel": "Abbrechen",
+            "%d OIDs in the list": "%d in der Liste",
+            "To many OIDs in the OIDLib": "Zu viele OIDs in der OIDLib"
         }
     }
 }

--- a/SNMP/locale.json
+++ b/SNMP/locale.json
@@ -28,8 +28,9 @@
             "Walking...": "Führe Walk durch...",
             "Walking... %d": "Führe Walk durch... %d",
             "Cancel": "Abbrechen",
-            "%d OIDs in the list": "%d in der Liste",
-            "To many OIDs in the OIDLib": "Zu viele OIDs in der OIDLib"
+            "%d OIDs in the list": "%d OIDs in der Liste",
+            "To many OIDs in the OIDLib": "Zu viele OIDs in der OIDLib",
+            "Found %d OIDs": "%d gefundene OIDs"
         }
     }
 }

--- a/SNMP/module.php
+++ b/SNMP/module.php
@@ -167,7 +167,7 @@ class SNMPWalk extends IPSModule
                 case 'gb':
                     $value *= (1024 ** 3);
                     break;
-                case't':
+                case 't':
                 case 'tb':
                     $value *= (1024 ** 4);
                     break;

--- a/SNMP/module.php
+++ b/SNMP/module.php
@@ -132,6 +132,7 @@ class SNMPWalk extends IPSModule
         $this->UpdateFormField('Bar', 'indeterminate', true);
         $this->UpdateFormField('Bar', 'maximum', 1);
         $this->UpdateFormField('Bar', 'current', 0);
+        $this->UpdateFormField('StopWalk', 'visible', true);
 
         // Create a cache of all previously created Idents for faster "Active?" evaluation
         $childrenIdents = [];
@@ -228,6 +229,7 @@ class SNMPWalk extends IPSModule
             $this->UpdateFormField('Bar', 'indeterminate', false);
             $this->UpdateFormField('Bar', 'current', 1);
             $this->UpdateFormField('Count', 'caption', sprintf($this->Translate('%d OIDs in the list'), count($values)));
+            $this->UpdateFormField('StopWalk', 'visible', false);
         } catch (\Exception $e) {
             // If we have an issue, display it here (network timeout, etc)
             echo $e->getMessage();

--- a/SNMP/module.php
+++ b/SNMP/module.php
@@ -221,12 +221,13 @@ class SNMPWalk extends IPSModule
 
                 $values[] = $value;
             }
+            $this->UpdateFormField('Bar', 'caption', sprintf($this->Translate('Found %d OIDs'), $count));
 
             $this->UpdateFormField('OIDList', 'values', json_encode($values));
 
             $this->UpdateFormField('Bar', 'indeterminate', false);
             $this->UpdateFormField('Bar', 'current', 1);
-            $this->UpdateFormField('Count', 'caption', sprintf($this->Translate('%d OIDs in the list.'), count($values)));
+            $this->UpdateFormField('Count', 'caption', sprintf($this->Translate('%d OIDs in the list'), count($values)));
         } catch (\Exception $e) {
             // If we have an issue, display it here (network timeout, etc)
             echo $e->getMessage();

--- a/SNMP/module.php
+++ b/SNMP/module.php
@@ -294,8 +294,8 @@ class SNMPWalk extends IPSModule
             foreach ($xml->list->entry as $entry) {
                 // Check if the buffer is under 1024 kb
                 if (strlen(json_encode($OIDs, JSON_FORCE_OBJECT)) * 8 / 1024 > 1024) {
-                    $this->UpdateFormField('Alert', "visible", true);
-                    $this->UpdateFormField('AlertLabel', "caption", $this->Translate('To many OIDs in the OIDLib'));
+                    $this->UpdateFormField('Alert', 'visible', true);
+                    $this->UpdateFormField('AlertLabel', 'caption', $this->Translate('To many OIDs in the OIDLib'));
                     $this->SetBuffer('IsWalking', 'no');
                     break;
                 }


### PR DESCRIPTION
- Wenn die OIDLib einen zu großen Buffer erzeugt, wird der Walk abgebrochen und ein PopupAlert angezeigt und keine OIDs. 
- Während des Walks wird geprüft ob weniger als 80% des Speichers genutzt wird. Wenn mehr genutzt wird, bricht der Walk ab, schreibt aber die OIDs in die Liste. 
- Da die OIDs aus der Lib teilweise ungeordnet auftauchen, kann der Walk nicht verkürzt werden. 

close https://github.com/symcon/modules/issues/243